### PR TITLE
fix: 暴露 dragEvent 以支持外部拖入 (Fixes #2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vue-grid-layout-next",
-  "version": "0.0.1",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vue-grid-layout-next",
-      "version": "0.0.1",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "@blueking/eslint-config-bk": "^2.1.0-beta.7",

--- a/packages/GridItem.tsx
+++ b/packages/GridItem.tsx
@@ -25,7 +25,7 @@ export default defineComponent({
   name: 'GridItem',
   props,
   emits: ['container-resized', 'resize', 'resized', 'move', 'moved'],
-  setup(props, { emit }) {
+  setup(props, { emit, expose }) {
     const eventBus = inject(eventBusKey) as Emitter<Record<EventType, unknown>>;
     const containerWidth = inject(containerWidthKey, ref(100));
     const rowHeight = inject(rowHeightKey, ref(10));
@@ -559,6 +559,11 @@ export default defineComponent({
       },
       // { immediate: true }
     );
+
+    expose({
+      calcXY,
+    });
+
     return {
       classObj,
       style,

--- a/packages/GridItem.vue
+++ b/packages/GridItem.vue
@@ -94,7 +94,7 @@ export default defineComponent({
     },
   },
   emits: ['container-resized', 'resize', 'resized', 'move', 'moved'],
-  setup(props, { emit }) {
+  setup(props, { emit, expose }) {
     const eventBus = inject(eventBusKey) as Emitter<Record<EventType, unknown>>;
     const containerWidth = inject(containerWidthKey, ref(100));
     const rowHeight = inject(rowHeightKey, ref(10));
@@ -628,6 +628,11 @@ export default defineComponent({
       },
       // { immediate: true }
     );
+
+    expose({
+      calcXY,
+    });
+
     return {
       classObj,
       style,

--- a/packages/GridLayout.tsx
+++ b/packages/GridLayout.tsx
@@ -47,7 +47,7 @@ export default defineComponent({
     'breakpoint-changed'
   ],
   props,
-  setup(props, { emit }) {
+  setup(props, { emit, expose }) {
 
     let eventBus = inject(eventBusKey) as Emitter<Record<EventType, unknown>>;
     if (!eventBus) {
@@ -351,6 +351,12 @@ export default defineComponent({
         })
       })
     })
+
+    expose({
+      dragEvent,
+      resizeEvent,
+    })
+
     return {
       mergedStyle,
       isDragging,

--- a/packages/GridLayout.vue
+++ b/packages/GridLayout.vue
@@ -177,7 +177,7 @@ export default defineComponent({
       default: false,
     },
   },
-  setup(props, { emit }) {
+  setup(props, { emit, expose }) {
     const eventBus = mitt();
     const layoutContainer = ref(null);
     provide(eventBusKey, eventBus);
@@ -465,6 +465,12 @@ export default defineComponent({
         });
       });
     });
+
+    expose({
+      dragEvent,
+      resizeEvent,
+    });
+
     return {
       mergedStyle,
       isDragging,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

仓库当前没有开放的 PR。根据 [Issue #2](https://github.com/zhl1232/v3-grid-layout/issues/2)，`GridLayout` 需要向父组件暴露 `dragEvent` 方法，以支持 vue-grid-layout v2 示例 10（从外部拖入元素）的使用场景。

## 变更说明

- 在 `GridLayout.tsx` / `GridLayout.vue` 的 `setup` 中通过 `expose()` 暴露：
  - `dragEvent` — 外部拖入时手动触发拖拽事件
  - `resizeEvent` — 与 v2 行为保持一致
- 在 `GridItem.tsx` / `GridItem.vue` 中暴露 `calcXY`，用于将鼠标坐标转换为栅格坐标（外部拖入场景所需）

## 使用示例

```vue
<template>
  <GridLayout ref="layoutRef" :layout="layout" />
</template>

<script setup>
import { ref } from 'vue'

const layoutRef = ref()

// 从外部拖入时调用
layoutRef.value?.dragEvent('dragstart', 'drop', x, y, h, w)
layoutRef.value?.dragEvent('dragend', 'drop', x, y, h, w)
</script>
```

## 验证

- `npm run build:lib` 通过（`vue-tsc` + vite build）

Closes #2
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c7b843c-63d2-4b16-9794-3ebdcb25bca7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c7b843c-63d2-4b16-9794-3ebdcb25bca7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grid layout and item components now expose internal utility methods through the component instance API. GridItem exposes coordinate calculation functionality, while GridLayout exposes drag and resize event handlers. This enables programmatic control of grid interactions and direct access to calculation utilities from parent components and external integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->