### PR TITLE
feat: 支持 GridItem 固定像素大小 (Fixes #1)

### DIFF
--- a/packages/GridItem.tsx
+++ b/packages/GridItem.tsx
@@ -12,6 +12,7 @@ import {
   rowHeightKey,
   maxRowsKey,
   colNumKey,
+  colWidthKey,
   containerWidthKey,
   marginKey,
   useCssTransformsKey,
@@ -32,6 +33,7 @@ export default defineComponent({
     const margin = inject(marginKey, ref([10, 10]));
     const maxRows = inject(maxRowsKey, ref(Infinity));
     const cols = inject(colNumKey, ref(12));
+    const fixedColWidth = inject(colWidthKey, ref(null));
     const useCssTransforms = inject(useCssTransformsKey, ref(true));
 
     const dragEventSet = ref(false);
@@ -231,7 +233,7 @@ export default defineComponent({
         createStyle();
       },
     );
-    watch([containerWidth, cols], () => {
+    watch([containerWidth, cols, fixedColWidth], () => {
       tryMakeResizable();
       createStyle();
       emitContainerResized();
@@ -274,7 +276,16 @@ export default defineComponent({
     // )
 
     // Helper for generating column width
-    const calcColWidth = () => (containerWidth.value - (margin.value[0] || 10) * (cols.value + 1)) / cols.value;
+    const calcColWidth = () => {
+      if (fixedColWidth.value && fixedColWidth.value > 0) {
+        return fixedColWidth.value;
+      }
+      return (containerWidth.value - (margin.value[0] || 10) * (cols.value + 1)) / cols.value;
+    };
+    const calcGridItemWHPx = (gridUnits: number, colOrRowSize: number, marginPx: number) => {
+      if (gridUnits === Infinity) return gridUnits;
+      return Math.round(colOrRowSize * gridUnits + Math.max(0, gridUnits - 1) * marginPx);
+    };
     const calcXY = (top: number, left: number) => {
       const colWidth = calcColWidth();
       // left = colWidth * x + margin * (x + 1)
@@ -374,27 +385,23 @@ export default defineComponent({
 
     function calcPosition(x: number, y: number, w: number, h: number, Rtl = renderRtl.value) {
       const colWidth = calcColWidth();
+      const width = props.pixelWidth ?? (w === Infinity ? w : calcGridItemWHPx(w, colWidth, margin.value[0]));
+      const height = props.pixelHeight ?? (h === Infinity ? h : calcGridItemWHPx(h, rowHeight.value, margin.value[1]));
       // add rtl support
       let out;
       if (Rtl) {
         out = {
           right: Math.round(colWidth * x + (x + 1) * margin.value[0]),
           top: Math.round(rowHeight.value * y + (y + 1) * margin.value[1]),
-          // 0 * Infinity === NaN, which causes problems with resize constriants;
-          // Fix this if it occurs.
-          // Note we do it here rather than later because Math.round(Infinity) causes deopt
-          width: w === Infinity ? w : Math.round(colWidth * w + Math.max(0, w - 1) * margin.value[0]),
-          height: h === Infinity ? h : Math.round(rowHeight.value * h + Math.max(0, h - 1) * margin.value[1]),
+          width,
+          height,
         };
       } else {
         out = {
           left: Math.round(colWidth * x + (x + 1) * margin.value[0]),
           top: Math.round(rowHeight.value * y + (y + 1) * margin.value[1]),
-          // 0 * Infinity === NaN, which causes problems with resize constriants;
-          // Fix this if it occurs.
-          // Note we do it here rather than later because Math.round(Infinity) causes deopt
-          width: w === Infinity ? w : Math.round(colWidth * w + Math.max(0, w - 1) * margin.value[0]),
-          height: h === Infinity ? h : Math.round(rowHeight.value * h + Math.max(0, h - 1) * margin.value[1]),
+          width,
+          height,
         };
       }
       return out;
@@ -558,6 +565,20 @@ export default defineComponent({
         createStyle();
       },
       // { immediate: true }
+    );
+    watch(
+      () => props.pixelWidth,
+      () => {
+        createStyle();
+        emitContainerResized();
+      },
+    );
+    watch(
+      () => props.pixelHeight,
+      () => {
+        createStyle();
+        emitContainerResized();
+      },
     );
 
     expose({

--- a/packages/GridItem.vue
+++ b/packages/GridItem.vue
@@ -20,6 +20,7 @@ import {
   rowHeightKey,
   maxRowsKey,
   colNumKey,
+  colWidthKey,
   containerWidthKey,
   marginKey,
   useCssTransformsKey,
@@ -92,6 +93,20 @@ export default defineComponent({
       type: String,
       default: 'a, button',
     },
+    /**
+     * 固定像素宽度。设置后该元素宽度不再随容器宽度变化，单位为像素。
+     */
+    pixelWidth: {
+      type: Number,
+      default: null,
+    },
+    /**
+     * 固定像素高度。设置后该元素高度不再随 rowHeight 变化，单位为像素。
+     */
+    pixelHeight: {
+      type: Number,
+      default: null,
+    },
   },
   emits: ['container-resized', 'resize', 'resized', 'move', 'moved'],
   setup(props, { emit, expose }) {
@@ -101,6 +116,7 @@ export default defineComponent({
     const margin = inject(marginKey, ref([10, 10]));
     const maxRows = inject(maxRowsKey, ref(Infinity));
     const cols = inject(colNumKey, ref(12));
+    const fixedColWidth = inject(colWidthKey, ref(null));
     const useCssTransforms = inject(useCssTransformsKey, ref(true));
 
     const dragEventSet = ref(false);
@@ -300,7 +316,7 @@ export default defineComponent({
         createStyle();
       },
     );
-    watch([containerWidth, cols], () => {
+    watch([containerWidth, cols, fixedColWidth], () => {
       tryMakeResizable();
       createStyle();
       emitContainerResized();
@@ -343,7 +359,16 @@ export default defineComponent({
     // )
 
     // Helper for generating column width
-    const calcColWidth = () => (containerWidth.value - (margin.value[0] || 10) * (cols.value + 1)) / cols.value;
+    const calcColWidth = () => {
+      if (fixedColWidth.value && fixedColWidth.value > 0) {
+        return fixedColWidth.value;
+      }
+      return (containerWidth.value - (margin.value[0] || 10) * (cols.value + 1)) / cols.value;
+    };
+    const calcGridItemWHPx = (gridUnits: number, colOrRowSize: number, marginPx: number) => {
+      if (gridUnits === Infinity) return gridUnits;
+      return Math.round(colOrRowSize * gridUnits + Math.max(0, gridUnits - 1) * marginPx);
+    };
     const calcXY = (top: number, left: number) => {
       const colWidth = calcColWidth();
       // left = colWidth * x + margin * (x + 1)
@@ -443,27 +468,23 @@ export default defineComponent({
 
     function calcPosition(x: number, y: number, w: number, h: number, Rtl = renderRtl.value) {
       const colWidth = calcColWidth();
+      const width = props.pixelWidth ?? (w === Infinity ? w : calcGridItemWHPx(w, colWidth, margin.value[0]));
+      const height = props.pixelHeight ?? (h === Infinity ? h : calcGridItemWHPx(h, rowHeight.value, margin.value[1]));
       // add rtl support
       let out;
       if (Rtl) {
         out = {
           right: Math.round(colWidth * x + (x + 1) * margin.value[0]),
           top: Math.round(rowHeight.value * y + (y + 1) * margin.value[1]),
-          // 0 * Infinity === NaN, which causes problems with resize constriants;
-          // Fix this if it occurs.
-          // Note we do it here rather than later because Math.round(Infinity) causes deopt
-          width: w === Infinity ? w : Math.round(colWidth * w + Math.max(0, w - 1) * margin.value[0]),
-          height: h === Infinity ? h : Math.round(rowHeight.value * h + Math.max(0, h - 1) * margin.value[1]),
+          width,
+          height,
         };
       } else {
         out = {
           left: Math.round(colWidth * x + (x + 1) * margin.value[0]),
           top: Math.round(rowHeight.value * y + (y + 1) * margin.value[1]),
-          // 0 * Infinity === NaN, which causes problems with resize constriants;
-          // Fix this if it occurs.
-          // Note we do it here rather than later because Math.round(Infinity) causes deopt
-          width: w === Infinity ? w : Math.round(colWidth * w + Math.max(0, w - 1) * margin.value[0]),
-          height: h === Infinity ? h : Math.round(rowHeight.value * h + Math.max(0, h - 1) * margin.value[1]),
+          width,
+          height,
         };
       }
       return out;
@@ -627,6 +648,20 @@ export default defineComponent({
         createStyle();
       },
       // { immediate: true }
+    );
+    watch(
+      () => props.pixelWidth,
+      () => {
+        createStyle();
+        emitContainerResized();
+      },
+    );
+    watch(
+      () => props.pixelHeight,
+      () => {
+        createStyle();
+        emitContainerResized();
+      },
     );
 
     expose({

--- a/packages/GridLayout.tsx
+++ b/packages/GridLayout.tsx
@@ -16,6 +16,7 @@ import {
   rowHeightKey,
   maxRowsKey,
   colNumKey,
+  colWidthKey,
   containerWidthKey,
   marginKey,
   useCssTransformsKey,
@@ -62,6 +63,7 @@ export default defineComponent({
     provide(rowHeightKey, toRef(props, 'rowHeight'))
     provide(maxRowsKey, toRef(props, 'maxRows'))
     provide(colNumKey, toRef(props, 'colNum'))
+    provide(colWidthKey, toRef(props, 'colWidth'))
     provide(marginKey, toRef(props, 'margin'))
     provide(useCssTransformsKey, toRef(props, 'useCssTransforms'))
 
@@ -99,9 +101,17 @@ export default defineComponent({
       return bottom(props.layout) * (props.rowHeight + props.margin[1]) + props.margin[1] + buffer + 'px'
     }
 
+    const containerWidthStyle = () => {
+      if (props.colWidth && props.colWidth > 0) {
+        return props.colWidth * props.colNum + props.margin[0] * (props.colNum + 1) + 'px'
+      }
+      return undefined
+    }
+
     const updateHeight = () => {
       mergedStyle.value = {
-        height: containerHeight()
+        height: containerHeight(),
+        ...(containerWidthStyle() ? { width: containerWidthStyle() } : {}),
       }
     }
     // watch(width, (newVal, oldVal) => {
@@ -157,7 +167,7 @@ export default defineComponent({
         emit('layout-updated', props.layout)
       }
     }
-    watch([() => props.layout.length, () => props.layout, () => props.margin], () => {
+    watch([() => props.layout.length, () => props.layout, () => props.margin, () => props.colWidth], () => {
       layoutUpdate()
     })
 

--- a/packages/GridLayout.vue
+++ b/packages/GridLayout.vue
@@ -33,6 +33,7 @@ import {
   rowHeightKey,
   maxRowsKey,
   colNumKey,
+  colWidthKey,
   containerWidthKey,
   marginKey,
   useCssTransformsKey,
@@ -81,6 +82,14 @@ export default defineComponent({
     rowHeight: {
       type: Number,
       default: 10,
+    },
+    /**
+     * 栅格每列的固定宽度，单位像素。设置后列宽不再随容器宽度自动分配，
+     * 可与 rowHeight 配合实现固定像素大小的栅格单元（如 60px 正方形）。
+     */
+    colWidth: {
+      type: Number,
+      default: null,
     },
     /**
      * 最大行数
@@ -188,6 +197,7 @@ export default defineComponent({
     provide(rowHeightKey, toRef(props, 'rowHeight'));
     provide(maxRowsKey, toRef(props, 'maxRows'));
     provide(colNumKey, toRef(props, 'colNum'));
+    provide(colWidthKey, toRef(props, 'colWidth'));
     provide(marginKey, toRef(props, 'margin'));
     provide(useCssTransformsKey, toRef(props, 'useCssTransforms'));
 
@@ -225,9 +235,17 @@ export default defineComponent({
       return `${bottom(props.layout) * (props.rowHeight + props.margin[1]) + props.margin[1] + buffer}px`;
     };
 
+    const containerWidthStyle = () => {
+      if (props.colWidth && props.colWidth > 0) {
+        return `${props.colWidth * props.colNum + props.margin[0] * (props.colNum + 1)}px`;
+      }
+      return undefined;
+    };
+
     const updateHeight = () => {
       mergedStyle.value = {
         height: containerHeight(),
+        ...(containerWidthStyle() ? { width: containerWidthStyle() } : {}),
       };
     };
     // watch(width, (newVal, oldVal) => {
@@ -271,7 +289,7 @@ export default defineComponent({
         emit('layout-updated', props.layout);
       }
     };
-    watch([() => props.layout.length, () => props.layout, () => props.margin], () => {
+    watch([() => props.layout.length, () => props.layout, () => props.margin, () => props.colWidth], () => {
       layoutUpdate();
     });
 

--- a/packages/helpers/utils.ts
+++ b/packages/helpers/utils.ts
@@ -440,6 +440,7 @@ export const isResizableKey: InjectionKey<Ref<boolean>> = Symbol('isResizable');
 export const rowHeightKey: InjectionKey<Ref<number>> = Symbol('rowHeight');
 export const maxRowsKey: InjectionKey<Ref<number>> = Symbol('maxRows');
 export const colNumKey: InjectionKey<Ref<number>> = Symbol('colNum');
+export const colWidthKey: InjectionKey<Ref<number | null>> = Symbol('colWidth');
 export const containerWidthKey: InjectionKey<Ref<number>> = Symbol('containerWidth');
 export const marginKey: InjectionKey<Ref<number[]>> = Symbol('margin');
 export const useCssTransformsKey: InjectionKey<Ref<boolean>> = Symbol('useCssTransforms');

--- a/packages/props.ts
+++ b/packages/props.ts
@@ -24,6 +24,14 @@ export const propsGridLayout = {
     default: 10,
   },
   /**
+   * 栅格每列的固定宽度，单位像素。设置后列宽不再随容器宽度自动分配，
+   * 可与 rowHeight 配合实现固定像素大小的栅格单元（如 60px 正方形）。
+   */
+  colWidth: {
+    type: Number as PropType<number | null>,
+    default: (): null => null,
+  },
+  /**
    * 最大行数
    */
   maxRows: {
@@ -179,5 +187,19 @@ export const propsGridItem = {
   resizeIgnoreFrom: {
     type: String,
     default: 'a, button',
+  },
+  /**
+   * 固定像素宽度。设置后该元素宽度不再随容器宽度变化，单位为像素。
+   */
+  pixelWidth: {
+    type: Number as PropType<number | null>,
+    default: (): null => null,
+  },
+  /**
+   * 固定像素高度。设置后该元素高度不再随 rowHeight 变化，单位为像素。
+   */
+  pixelHeight: {
+    type: Number as PropType<number | null>,
+    default: (): null => null,
   },
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

Closes #1

用户希望 GridItem 能设置固定像素宽高（如 60px 正方形），而不是只能依赖 `col-num` 自动分配列宽。

## 改动

### GridLayout 新增 `colWidth`

- 设置固定列宽（像素）后，列宽不再随容器宽度变化
- 容器宽度自动按 `colWidth * colNum + margin` 计算
- 配合 `rowHeight` 可实现统一固定尺寸的栅格单元

### GridItem 新增 `pixelWidth` / `pixelHeight`

- 支持为单个元素设置固定像素宽高
- 适用于同一布局中不同元素需要不同固定尺寸的场景

## 使用示例

**方式一：布局级固定尺寸（推荐，适合统一正方形栅格）**

```vue
<GridLayout :col-width="60" :row-height="60" :col-num="12" :layout="layout">
  <GridItem v-for="item in layout" :key="item.i" v-bind="item" />
</GridLayout>
```

设置 `col-width="60"` 和 `row-height="60"` 后，`w=1, h=1` 的元素即为 60px 正方形。

**方式二：单个元素固定尺寸**

```vue
<GridItem :w="1" :h="1" :pixel-width="60" :pixel-height="60" ... />
```

## 测试

- [x] `npm run build:lib` 通过（TypeScript 类型检查 + 打包）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7b1cff8-935b-4487-8d04-a7ebc875b823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7b1cff8-935b-4487-8d04-a7ebc875b823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

