### PR TITLE
fix: 修复 GitHub Pages Jekyll 构建失败（缺少 docs 目录）

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,54 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Storybook
+        run: NODE_OPTIONS=--openssl-legacy-provider npm run build:doc
+
+      - name: Prepare static site
+        run: touch storybook-static/.nojekyll
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: storybook-static
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

GitHub Pages 的 `pages-build-deployment` 工作流使用 `jekyll-build-pages@v1`，配置为从 `/docs` 目录构建站点。但该目录已在 2022 年的提交中被移除（`2cb3355`），导致构建失败：

```
No such file or directory @ dir_chdir0 - /github/workspace/docs
```

## 原因

- 仓库曾将 Storybook 构建产物提交到 `docs/` 目录用于 GitHub Pages
- 后续提交删除了 `docs/` 目录，但 GitHub Pages 设置仍指向 `/docs` 分支文件夹
- Jekyll 尝试处理 `assets/css/style.scss` 时无法进入不存在的 `docs` 目录

## 修复方案

新增 `.github/workflows/deploy-pages.yml` 工作流：

1. 在 CI 中运行 `npm run build:doc` 构建 Storybook 静态站点
2. 添加 `.nojekyll` 文件，跳过 Jekyll 处理
3. 通过 `actions/upload-pages-artifact` + `actions/deploy-pages` 部署到 GitHub Pages

## 合并后需要手动操作

请在仓库 **Settings → Pages** 中将发布源从 **"Deploy from a branch / docs"** 改为 **"GitHub Actions"**，否则旧的 `jekyll-build-pages` 工作流仍会触发并失败。

## 技术说明

- 使用 Node.js 18 构建
- 需要 `NODE_OPTIONS=--openssl-legacy-provider` 以兼容项目中的 Webpack 4 依赖
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9dfcbcd9-e747-4753-981f-7bc310ecea26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9dfcbcd9-e747-4753-981f-7bc310ecea26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

