### PR TITLE
fix(ci): upgrade deploy-pages workflow to Node 22 for Storybook 10

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -25,14 +25,16 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
         run: npm ci
 
       - name: Build Storybook
-        run: NODE_OPTIONS=--openssl-legacy-provider npm run build:doc
+        env:
+          STORYBOOK_DISABLE_TELEMETRY: '1'
+        run: npm run build:doc
 
       - name: Prepare static site
         run: touch storybook-static/.nojekyll


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the GitHub Pages deploy workflow failure when building Storybook documentation.

Storybook 10 requires Node.js 20.19+ or 22.12+, but `deploy-pages.yml` was still pinned to Node 18. This caused `npm run build:doc` to fail with:

> To run Storybook, you need Node.js version 20.19+ or 22.12+.

## Changes

- Upgrade `deploy-pages.yml` from Node 18 to Node 22 (aligned with `ci.yml` and `package.json` `engines`)
- Remove `NODE_OPTIONS=--openssl-legacy-provider` (no longer needed on Node 22)
- Add `STORYBOOK_DISABLE_TELEMETRY=1` to match the CI docs job

## Verification

- `npm run build:doc` succeeds locally on Node 22.14.0
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56bc0fbf-8f9d-4e21-a997-6e8156966d6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56bc0fbf-8f9d-4e21-a997-6e8156966d6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

