### PR TITLE
chore: 统一 npm 包名为 v3-grid-layout 并添加自动发布流程

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm run test
+
+      - name: Build library
+        run: npm run build:lib
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          VERSION="${TAG#v}"
+          NOTES_FILE=$(mktemp)
+          if [ -f "CHANGELOG.md" ]; then
+            awk -v version="$VERSION" '
+              $0 ~ "^## \\[" version "\\]" { found=1; next }
+              found && /^## \[/ { exit }
+              found { print }
+            ' CHANGELOG.md > "$NOTES_FILE"
+          fi
+          if [ ! -s "$NOTES_FILE" ]; then
+            echo "Release $TAG" > "$NOTES_FILE"
+            echo "" >> "$NOTES_FILE"
+            echo "See the [commit history](https://github.com/${{ github.repository }}/compare/${TAG}^...${TAG}) for details." >> "$NOTES_FILE"
+          fi
+          gh release create "$TAG" \
+            --title "v$VERSION" \
+            --notes-file "$NOTES_FILE"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0] - 2026-06-22
+
+### Added
+
+- Vue 3 Composition API rewrite with strict TypeScript types
+- Storybook documentation site deployed to GitHub Pages
+- CI pipeline (lint, typecheck, test, build, audit)
+- Automated npm publish and GitHub Release on version tags
+
+### Changed
+
+- npm package name unified to `v3-grid-layout` (replaces in-repo `vue-grid-layout-next` name; the `vue-grid-layout-next` name on npm is owned by another publisher)

--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
-# vue-grid-layout-next
+# v3-grid-layout
 
 A powerful, draggable, and resizable grid layout component built natively for **Vue 3** and **TypeScript**.
 
-[![npm version](https://img.shields.io/npm/v/vue-grid-layout-next.svg)](https://www.npmjs.com/package/vue-grid-layout-next)
+[![npm version](https://img.shields.io/npm/v/v3-grid-layout.svg)](https://www.npmjs.com/package/v3-grid-layout)
 [![GitHub license](https://img.shields.io/github/license/zhl1232/v3-grid-layout.svg)](LICENSE)
 
-> Also known as **v3-grid-layout** in documentation and legacy references.
+> npm 包名为 **`v3-grid-layout`**。项目开发期曾使用 `vue-grid-layout-next` 作为内部代号；npm 上的 `vue-grid-layout-next` 已被他人占用，因此发布统一使用 `v3-grid-layout`。
 
 **[📖 Live documentation (Storybook)](https://zhl1232.github.io/v3-grid-layout/)**
 
-## Why vue-grid-layout-next?
+## Why v3-grid-layout?
 
 The original [`vue-grid-layout`](https://github.com/jbaysolutions/vue-grid-layout) library has been abandoned for years and lacks official Vue 3 support. This project is a modernized successor with Composition API, TypeScript, and Vite-friendly builds.
 
 ## Install
 
 ```bash
-npm install vue-grid-layout-next
+npm install v3-grid-layout
 # or
-pnpm add vue-grid-layout-next
+pnpm add v3-grid-layout
 # or
-yarn add vue-grid-layout-next
+yarn add v3-grid-layout
 ```
 
 `vue` ^3.5.0 is required as a peer dependency. Node.js >= 20.19 is required for development.
@@ -32,8 +32,8 @@ yarn add vue-grid-layout-next
 ```ts
 import { createApp } from 'vue'
 import App from './App.vue'
-import GridLayoutPlugin from 'vue-grid-layout-next'
-import 'vue-grid-layout-next/dist/style.css'
+import GridLayoutPlugin from 'v3-grid-layout'
+import 'v3-grid-layout/dist/style.css'
 
 createApp(App).use(GridLayoutPlugin).mount('#app')
 ```
@@ -43,9 +43,9 @@ createApp(App).use(GridLayoutPlugin).mount('#app')
 ```vue
 <script setup lang="ts">
 import { ref } from 'vue'
-import { GridItem, GridLayout } from 'vue-grid-layout-next'
-import type { Layout } from 'vue-grid-layout-next'
-import 'vue-grid-layout-next/dist/style.css'
+import { GridItem, GridLayout } from 'v3-grid-layout'
+import type { Layout } from 'v3-grid-layout'
+import 'v3-grid-layout/dist/style.css'
 
 const layout = ref<Layout>([
   { x: 0, y: 0, w: 2, h: 2, i: '0' },
@@ -96,7 +96,7 @@ The full API reference (props, events, expose methods, and layout types) lives i
 ### Layout type
 
 ```ts
-import type { Layout, LayoutItem } from 'vue-grid-layout-next'
+import type { Layout, LayoutItem } from 'v3-grid-layout'
 
 const item: LayoutItem = { i: 'a', x: 0, y: 0, w: 2, h: 2 }
 const layout: Layout = [item]
@@ -124,6 +124,8 @@ npm run storybook  # component docs at http://localhost:6006
 | `npm run audit` | Audit all dependencies |
 | `npm run audit:prod` | Audit production dependencies only |
 | `npm run storybook` | Component documentation |
+
+发布新版本请参阅 [RELEASING.md](RELEASING.md)。
 
 ## Related Projects
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,39 @@
+# 发布指南
+
+## 一次性配置
+
+在 GitHub 仓库 **Settings → Secrets and variables → Actions** 中添加：
+
+| Secret | 说明 |
+|--------|------|
+| `NPM_TOKEN` | [npm Access Token](https://www.npmjs.com/settings/~tokens)（Automation 类型，需 publish 权限） |
+
+仓库 **About** 建议填写：
+
+| 字段 | 值 |
+|------|-----|
+| Description | Vue 3 draggable and resizable grid layout component library |
+| Website | https://zhl1232.github.io/v3-grid-layout/ |
+| Topics | `vue3`, `vue`, `grid-layout`, `typescript`, `draggable`, `resizable`, `storybook` |
+
+## 发布流程
+
+1. 更新 `package.json` 中的 `version`
+2. （可选）在 `CHANGELOG.md` 添加对应版本的更新说明
+3. 提交并推送到 `master`
+4. 打 tag 并推送，触发自动发布：
+
+```bash
+git tag v2.0.0
+git push origin v2.0.0
+```
+
+推送 tag 后，[Release workflow](.github/workflows/release.yml) 会依次执行：
+
+- lint / typecheck / test / build
+- 发布到 [npm](https://www.npmjs.com/package/v3-grid-layout)
+- 创建 [GitHub Release](https://github.com/zhl1232/v3-grid-layout/releases)
+
+## 包名说明
+
+npm 包名为 **`v3-grid-layout`**（仓库所有者名下已有此包）。`vue-grid-layout-next` 在 npm 上已被他人占用，因此统一使用 `v3-grid-layout`。

--- a/build/lib.config.ts
+++ b/build/lib.config.ts
@@ -18,8 +18,8 @@ export default defineConfig({
     outDir: 'dist',
     lib: {
       entry: resolve(__dirname, '../packages/index.ts'),
-      name: 'VueGridLayoutNext',
-      fileName: format => `vue-grid-layout-next.${format === 'es' ? 'es' : 'umd'}.js`,
+      name: 'V3GridLayout',
+      fileName: format => `v3-grid-layout.${format === 'es' ? 'es' : 'umd'}.js`,
       formats: ['es', 'umd']
     },
     rollupOptions: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "vue-grid-layout-next",
-  "version": "0.0.7",
+  "name": "v3-grid-layout",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vue-grid-layout-next",
-      "version": "0.0.7",
+      "name": "v3-grid-layout",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@vueuse/core": "^14.3.0",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "vue-grid-layout-next",
-  "version": "0.0.7",
+  "name": "v3-grid-layout",
+  "version": "2.0.0",
   "private": false,
   "license": "MIT",
-  "main": "dist/vue-grid-layout-next.umd.js",
-  "module": "dist/vue-grid-layout-next.es.js",
+  "main": "dist/v3-grid-layout.umd.js",
+  "module": "dist/v3-grid-layout.es.js",
   "types": "dist/index.d.ts",
   "style": "dist/style.css",
   "files": [

--- a/src/stories/API.mdx
+++ b/src/stories/API.mdx
@@ -129,10 +129,10 @@ type LayoutItem = {
 type Layout = LayoutItem[]
 ```
 
-可从 `vue-grid-layout-next` 包导入：
+可从 `v3-grid-layout` 包导入：
 
 ```ts
-import type { Layout, LayoutItem } from 'vue-grid-layout-next'
+import type { Layout, LayoutItem } from 'v3-grid-layout'
 ```
 
 ---
@@ -141,11 +141,11 @@ import type { Layout, LayoutItem } from 'vue-grid-layout-next'
 
 ```ts
 // 全局注册
-import GridLayoutPlugin from 'vue-grid-layout-next'
-import 'vue-grid-layout-next/dist/style.css'
+import GridLayoutPlugin from 'v3-grid-layout'
+import 'v3-grid-layout/dist/style.css'
 app.use(GridLayoutPlugin)
 
 // 局部注册
-import { GridLayout, GridItem } from 'vue-grid-layout-next'
-import 'vue-grid-layout-next/dist/style.css'
+import { GridLayout, GridItem } from 'v3-grid-layout'
+import 'v3-grid-layout/dist/style.css'
 ```

--- a/src/stories/Introduction.mdx
+++ b/src/stories/Introduction.mdx
@@ -2,7 +2,7 @@ import { Meta } from '@storybook/addon-docs/blocks'
 
 <Meta title="说明" />
 
-# vue-grid-layout-next
+# v3-grid-layout
 
 Vue 3 可拖拽、可缩放的栅格布局组件库，基于 [interact.js](https://interactjs.io/) 实现。
 
@@ -19,11 +19,11 @@ Vue 3 可拖拽、可缩放的栅格布局组件库，基于 [interact.js](https
 ## 安装
 
 ```bash
-npm install vue-grid-layout-next
+npm install v3-grid-layout
 # 或
-pnpm add vue-grid-layout-next
+pnpm add v3-grid-layout
 # 或
-yarn add vue-grid-layout-next
+yarn add v3-grid-layout
 ```
 
 需要 `vue` ^3.5.0 作为 peer dependency。
@@ -35,8 +35,8 @@ yarn add vue-grid-layout-next
 ```js
 import { createApp } from 'vue'
 import App from './App.vue'
-import GridLayoutPlugin from 'vue-grid-layout-next'
-import 'vue-grid-layout-next/dist/style.css'
+import GridLayoutPlugin from 'v3-grid-layout'
+import 'v3-grid-layout/dist/style.css'
 
 createApp(App).use(GridLayoutPlugin).mount('#app')
 ```
@@ -46,9 +46,9 @@ createApp(App).use(GridLayoutPlugin).mount('#app')
 ```vue
 <script setup lang="ts">
 import { ref } from 'vue'
-import { GridItem, GridLayout } from 'vue-grid-layout-next'
-import type { Layout } from 'vue-grid-layout-next'
-import 'vue-grid-layout-next/dist/style.css'
+import { GridItem, GridLayout } from 'v3-grid-layout'
+import type { Layout } from 'v3-grid-layout'
+import 'v3-grid-layout/dist/style.css'
 
 const layout = ref<Layout>([
   { x: 0, y: 0, w: 2, h: 2, i: '0' },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

补全 GitHub 仓库发布相关配置，统一可发布的 npm 包名，并添加 tag 触发的自动发布流程。

## Changes

- **包名统一**：`vue-grid-layout-next` → `v3-grid-layout@2.0.0`（npm 上 `vue-grid-layout-next` 已被他人占用，仓库所有者名下已有 `v3-grid-layout`）
- **构建产物**：`dist/v3-grid-layout.{es,umd}.js`
- **文档同步**：更新 README、Storybook MDX 中的安装与 import 示例
- **发布流程**：新增 `.github/workflows/release.yml`，推送 `v*.*.*` tag 后自动 lint / test / build → npm publish → GitHub Release
- **发布文档**：新增 `RELEASING.md` 与 `CHANGELOG.md`

## Manual steps after merge

1. 在 GitHub **Settings → Secrets → Actions** 添加 `NPM_TOKEN`（npm Automation token）
2. 在仓库 **About** 填写：
   - Description: `Vue 3 draggable and resizable grid layout component library`
   - Website: `https://zhl1232.github.io/v3-grid-layout/`
   - Topics: `vue3`, `vue`, `grid-layout`, `typescript`, `draggable`, `resizable`, `storybook`
3. 合并后打 tag 发布首版：
   ```bash
   git tag v2.0.0
   git push origin v2.0.0
   ```

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test`
- [x] `npm run build:lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c56bbb41-7eb4-4337-82c3-13e3db48b17e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c56bbb41-7eb4-4337-82c3-13e3db48b17e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

