### PR TITLE
ci: 改用 Trusted Publishing 发布 npm 包

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,6 @@ jobs:
         run: npm run build:lib
 
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance --access public
 
       - name: Create GitHub Release

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,12 +1,18 @@
 # 发布指南
 
-## 一次性配置
+## 一次性配置（推荐：Trusted Publishing）
 
-在 GitHub 仓库 **Settings → Secrets and variables → Actions** 中添加：
+在 [npm 包设置页](https://www.npmjs.com/package/v3-grid-layout/settings) 配置 **Trusted Publisher**，让 GitHub Actions 通过 OIDC 直接发布，无需 `NPM_TOKEN`：
 
-| Secret | 说明 |
-|--------|------|
-| `NPM_TOKEN` | [npm Access Token](https://www.npmjs.com/settings/~tokens)（Automation 类型，需 publish 权限） |
+| 字段 | 值 |
+|------|-----|
+| Provider | GitHub Actions |
+| Repository owner | `zhl1232` |
+| Repository name | `v3-grid-layout` |
+| Workflow filename | `release.yml` |
+| Environment name | 留空 |
+
+路径：**npm 包页 → Settings → Publishing access → Trusted publishers → Add**
 
 仓库 **About** 建议填写：
 
@@ -15,6 +21,10 @@
 | Description | Vue 3 draggable and resizable grid layout component library |
 | Website | https://zhl1232.github.io/v3-grid-layout/ |
 | Topics | `vue3`, `vue`, `grid-layout`, `typescript`, `draggable`, `resizable`, `storybook` |
+
+### 备选：NPM_TOKEN
+
+若不用 Trusted Publishing，可在 GitHub **Settings → Secrets → Actions → Repository secrets** 添加 `NPM_TOKEN`（Granular token，需 **Read and write** + **Bypass 2FA**），并在 workflow 中恢复 `NODE_AUTH_TOKEN` 环境变量。
 
 ## 发布流程
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

将 npm 发布从 `NPM_TOKEN` 切换为 npm 官方推荐的 **Trusted Publishing**（GitHub Actions OIDC），避免 Bypass 2FA token 配置问题。

## Changes

- 移除 `NODE_AUTH_TOKEN` 依赖
- 更新 `RELEASING.md` 说明 Trusted Publisher 配置步骤

## Required before release

在 npm 包设置页添加 Trusted Publisher（见 RELEASING.md）。

## Test plan

- [ ] 配置 Trusted Publisher 后重新推送 `v2.0.0` tag
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c56bbb41-7eb4-4337-82c3-13e3db48b17e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c56bbb41-7eb4-4337-82c3-13e3db48b17e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow authentication to use a more secure identity verification method instead of manual token-based authentication.
  * Updated release documentation with configuration instructions for the new authentication approach and a fallback alternative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->